### PR TITLE
Fix view template name generation on Windows

### DIFF
--- a/ez-gin-template.go
+++ b/ez-gin-template.go
@@ -98,7 +98,7 @@ func (r Render) findPartials(findPartialDir string) []string {
 }
 func (r Render) getRenderName(tpl string) string {
 	dir, file := filepath.Split(tpl)
-	dir = strings.Replace(dir, r.TemplatesDir, "", 1)
+	dir = strings.Replace(filepath.ToSlash(dir), filepath.ToSlash(r.TemplatesDir), "", 1)
 	file = strings.TrimSuffix(file, r.Ext)
 	return dir + file
 }


### PR DESCRIPTION
On Linux & Mac `Render.getRenderName()` generated a name in the format `view-subdir/template-file`, while on Windows the generated name was `view-subdir\template-file`. Since the generated name is
used as an identifier in `Render.Templates` it was impossible to refer to a template in a cross-platform manner. This change ensures that the generate template names always contain forward-slashes, even on Windows.